### PR TITLE
Add ranking system for learning prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# ai-profit-suite
+# AI Profit Suite
+
+This simple tool helps you track daily learning prompts and rank them based on their usefulness. The program records ratings for each prompt, sorts them by average score, and removes items you mark with a score of `0`.
+
+## Usage
+
+Run the script with Python:
+
+```bash
+python3 main.py
+```
+
+You will be prompted to rate each learning strategy from 1 (least helpful) to 5 (most helpful). Enter `0` if the prompt was not helpful and should be discarded. After rating, the updated prompt list is saved to `prompts.json` and displayed in ranked order.

--- a/main.py
+++ b/main.py
@@ -1,1 +1,66 @@
-print("AI Profit Suite Initialized.")
+import json
+from pathlib import Path
+
+PROMPT_FILE = Path('prompts.json')
+
+DEFAULT_PROMPTS = [
+    {"prompt": "Read documentation for 30 minutes", "ratings": []},
+    {"prompt": "Complete a coding challenge", "ratings": []},
+    {"prompt": "Watch a tutorial video", "ratings": []}
+]
+
+def load_prompts():
+    if PROMPT_FILE.exists():
+        with PROMPT_FILE.open('r') as f:
+            return json.load(f)
+    else:
+        with PROMPT_FILE.open('w') as f:
+            json.dump(DEFAULT_PROMPTS, f, indent=2)
+        return DEFAULT_PROMPTS
+
+
+def save_prompts(prompts):
+    with PROMPT_FILE.open('w') as f:
+        json.dump(prompts, f, indent=2)
+
+
+def get_score(prompt):
+    ratings = prompt.get('ratings', [])
+    return sum(ratings) / len(ratings) if ratings else 0
+
+
+def ask_for_ratings(prompts):
+    updated = []
+    for p in prompts:
+        print(f"\nPrompt: {p['prompt']}")
+        try:
+            rating = int(input("Rate from 1-5 (0 to remove): "))
+        except ValueError:
+            print("Invalid input, skipping")
+            continue
+        if rating == 0:
+            continue  # discard prompt
+        p.setdefault('ratings', []).append(rating)
+        p['score'] = get_score(p)
+        updated.append(p)
+    updated.sort(key=lambda x: x.get('score', 0), reverse=True)
+    return updated
+
+
+def display_prompts(prompts):
+    print("\nRanked strategies:")
+    for p in prompts:
+        score = get_score(p)
+        print(f"- {p['prompt']} (score: {score:.2f})")
+
+
+def main():
+    print("AI Profit Suite Initialized.")
+    prompts = load_prompts()
+    prompts = ask_for_ratings(prompts)
+    save_prompts(prompts)
+    display_prompts(prompts)
+
+
+if __name__ == '__main__':
+    main()

--- a/prompts.json
+++ b/prompts.json
@@ -1,0 +1,5 @@
+[
+  {"prompt": "Read documentation for 30 minutes", "ratings": []},
+  {"prompt": "Complete a coding challenge", "ratings": []},
+  {"prompt": "Watch a tutorial video", "ratings": []}
+]


### PR DESCRIPTION
## Summary
- build interactive ranking flow for learning prompts
- store prompt info in `prompts.json`
- document how to use the ranking tool

## Testing
- `python3 main.py <<'EOF'
5
4
3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6882e00790ac832fb16655fca6a13c72